### PR TITLE
Jyu ka

### DIFF
--- a/pocketmark_backend/build.gradle
+++ b/pocketmark_backend/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/PocketmarkApplication.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/PocketmarkApplication.java
@@ -2,8 +2,10 @@ package com.example.pocketmark;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class PocketmarkApplication {
 
 	public static void main(String[] args) {

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/config/AsyncConfig.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.example.pocketmark.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean("async-thread")
+    public Executor asyncThread(){
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setMaxPoolSize(100);
+        threadPoolTaskExecutor.setCorePoolSize(10);     // core 에서 10개가 모두 차면 queue 에 1이 차는 형식
+        threadPoolTaskExecutor.setQueueCapacity(10);
+        threadPoolTaskExecutor.setThreadNamePrefix("Async-");
+
+        return threadPoolTaskExecutor;
+    }
+}

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/config/WebSecurityConfig.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/config/WebSecurityConfig.java
@@ -59,7 +59,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
                 .antMatchers("/api/v1/sign-up","/api/v1/login",
                         "/api/v1/email-check","/api/v1/alias-check",
                         "/api/v1/refresh-token",
-                        "/api/v1/send-authentication-email"
+                        "/api/v1/send-authentication-email",
+                        "/api/v1/authentication-email"
 
                 ).permitAll()
 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/config/WebSecurityConfig.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/config/WebSecurityConfig.java
@@ -58,7 +58,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
 
                 .antMatchers("/api/v1/sign-up","/api/v1/login",
                         "/api/v1/email-check","/api/v1/alias-check",
-                        "/api/v1/refresh-token"
+                        "/api/v1/refresh-token",
+                        "/api/v1/send-authentication-email"
 
                 ).permitAll()
 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/constant/ErrorCode.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/constant/ErrorCode.java
@@ -45,7 +45,8 @@ public enum ErrorCode {
     TOKEN_NOT_VALID(50003,HttpStatus.UNAUTHORIZED,"Token not valid"),
     REFRESH_TOKEN_NOT_VALID(50004,HttpStatus.UNAUTHORIZED,"Refresh token not valid"),
     NOT_FOUND_SIGNATURE(50005,HttpStatus.UNAUTHORIZED,"Not found signature in Jwt"),
-    IS_TOKEN_DIFFERENT(50006,HttpStatus.UNAUTHORIZED, "The types of tokens are different.")
+    IS_TOKEN_DIFFERENT(50006,HttpStatus.UNAUTHORIZED, "The types of tokens are different."),
+    EMAIL_AUTHENTICATION_CODE_EXPIRE(50007,HttpStatus.BAD_REQUEST,"Email authentication code is expired.")
     ;
 
     private final Integer code;

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/AuthenticationController.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/AuthenticationController.java
@@ -2,13 +2,16 @@ package com.example.pocketmark.controller.api;
 
 import com.example.pocketmark.dto.LoginDto;
 import com.example.pocketmark.dto.RefreshToken;
+import com.example.pocketmark.dto.SendAuthenticationEmail;
 import com.example.pocketmark.dto.common.ApiDataResponse;
 import com.example.pocketmark.security.provider.JwtUtil;
 import com.example.pocketmark.security.provider.TokenBox;
 import com.example.pocketmark.service.AuthenticationService;
 import com.example.pocketmark.service.DataService;
+import com.example.pocketmark.service.EmailService;
 import com.example.pocketmark.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
+import static com.example.pocketmark.dto.SendAuthenticationEmail.SendAuthenticationEmailDto.fromSendAuthenticationEmailReq;
 
 import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +27,7 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
     private final RefreshTokenService refreshTokenService;
     private final DataService dataService;
+    private final EmailService emailService;
 
     @PostMapping("/login")
     public ApiDataResponse<LoginDto.LoginRes> login(
@@ -47,5 +51,15 @@ public class AuthenticationController {
         );
 
         return ApiDataResponse.of(res);
+    }
+
+
+    @PostMapping("/send-authentication-email")
+    public ApiDataResponse<ApiDataResponse.GeneralResponse> sendAuthenticationEmail(
+            @RequestBody SendAuthenticationEmail.SendAuthenticationEmailReq req
+    ){
+
+        emailService.sendSignUpAuthenticationMail(fromSendAuthenticationEmailReq(req));
+        return ApiDataResponse.success();
     }
 }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/AuthenticationController.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/AuthenticationController.java
@@ -1,5 +1,6 @@
 package com.example.pocketmark.controller.api;
 
+import com.example.pocketmark.dto.AuthenticationEmail;
 import com.example.pocketmark.dto.LoginDto;
 import com.example.pocketmark.dto.RefreshToken;
 import com.example.pocketmark.dto.SendAuthenticationEmail;
@@ -61,5 +62,24 @@ public class AuthenticationController {
 
         emailService.sendSignUpAuthenticationMail(fromSendAuthenticationEmailReq(req));
         return ApiDataResponse.success();
+    }
+
+
+    @PostMapping("/authentication-email")
+    public ApiDataResponse<AuthenticationEmail.AuthenticationEmailRes> authenticationEmail(
+            @RequestBody AuthenticationEmail.AuthenticationEmailReq req
+    ){
+
+        boolean authenticationResult = emailService.authenticateEmail(
+                AuthenticationEmail.AuthenticationEmailDto
+                        .fromSendAuthenticationEmailReq(req)
+        );
+
+        return ApiDataResponse.of(
+                AuthenticationEmail.AuthenticationEmailRes
+                        .builder()
+                        .success(authenticationResult)
+                        .build()
+        );
     }
 }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/domain/EmailAuthenticationCode.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/domain/EmailAuthenticationCode.java
@@ -1,0 +1,20 @@
+package com.example.pocketmark.domain;
+
+import com.example.pocketmark.domain.base.BaseTimeEntityWithId;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Getter
+public class EmailAuthenticationCode extends BaseTimeEntityWithId {
+
+    private String email;
+    private String code;
+}

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/domain/EmailAuthenticationCode.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/domain/EmailAuthenticationCode.java
@@ -17,4 +17,9 @@ public class EmailAuthenticationCode extends BaseTimeEntityWithId {
 
     private String email;
     private String code;
+    private boolean success;
+
+    public void successAuthenticate(){
+        this.success = true;
+    }
 }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/dto/AuthenticationEmail.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/dto/AuthenticationEmail.java
@@ -1,0 +1,51 @@
+package com.example.pocketmark.dto;
+
+import lombok.*;
+
+public class AuthenticationEmail {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class AuthenticationEmailDto{
+
+        private String email;
+        private String code;
+
+        public static AuthenticationEmailDto fromSendAuthenticationEmailReq(AuthenticationEmailReq request){
+            return AuthenticationEmailDto.builder()
+                    .email(request.getEmail())
+                    .code(request.getCode())
+                    .build()
+                    ;
+        }
+
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class AuthenticationEmailReq{
+        private String email;
+        private String code;
+    }
+
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class AuthenticationEmailRes{
+
+        private boolean success;
+
+    }
+}

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/dto/SendAuthenticationEmail.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/dto/SendAuthenticationEmail.java
@@ -1,0 +1,51 @@
+package com.example.pocketmark.dto;
+
+import lombok.*;
+
+public class SendAuthenticationEmail {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class SendAuthenticationEmailDto{
+
+        private String email;
+
+        public static SendAuthenticationEmailDto fromSendAuthenticationEmailReq(SendAuthenticationEmailReq request){
+            return SendAuthenticationEmailDto.builder()
+                    .email(request.getEmail())
+                    .build()
+                    ;
+        }
+
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @ToString
+    public static class SendAuthenticationEmailReq{
+        private String email;
+    }
+
+//
+//    @Getter
+//    @Setter
+//    @AllArgsConstructor
+//    @NoArgsConstructor
+//    @Builder
+//    @ToString
+//    public static class SendAuthenticationEmailRes{
+//
+//        private boolean success;
+//
+//    }
+
+
+
+}

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/repository/EmailAuthenticationCodeRepository.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/repository/EmailAuthenticationCodeRepository.java
@@ -1,0 +1,7 @@
+package com.example.pocketmark.repository;
+
+import com.example.pocketmark.domain.EmailAuthenticationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailAuthenticationCodeRepository extends JpaRepository<EmailAuthenticationCode, Long> {
+}

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/repository/EmailAuthenticationCodeRepository.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/repository/EmailAuthenticationCodeRepository.java
@@ -4,4 +4,6 @@ import com.example.pocketmark.domain.EmailAuthenticationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmailAuthenticationCodeRepository extends JpaRepository<EmailAuthenticationCode, Long> {
+
+    EmailAuthenticationCode findFirstByEmailOrderByCreatedAtDesc(String email);
 }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/service/EmailService.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/service/EmailService.java
@@ -6,6 +6,7 @@ import com.example.pocketmark.repository.EmailAuthenticationCodeRepository;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.Locale;
@@ -31,6 +32,7 @@ public class EmailService {
     }
 
 
+    @Async
     public void sendSignUpAuthenticationMail(SendAuthenticationEmailDto dto){
         String authenticationCode = makeEmailAuthenticationCode();
 
@@ -43,7 +45,7 @@ public class EmailService {
         final MimeMessagePreparator preparator = message -> {
             final MimeMessageHelper helper = new MimeMessageHelper(message);
             helper.setTo(dto.getEmail());
-            helper.setSubject("PocketMark 회원가입 이메일 인증코드");
+            helper.setSubject("[PocketMark] 회원가입 이메일 인증코드");
             helper.setText(authenticationCode);
         };
 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/service/EmailService.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/service/EmailService.java
@@ -1,0 +1,64 @@
+package com.example.pocketmark.service;
+
+import com.example.pocketmark.domain.EmailAuthenticationCode;
+import com.example.pocketmark.dto.SendAuthenticationEmail.SendAuthenticationEmailDto;
+import com.example.pocketmark.repository.EmailAuthenticationCodeRepository;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+import java.util.Random;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender emailSender;
+    private final EmailAuthenticationCodeRepository emailAuthenticationCodeRepository;
+    private final int leftLimit;
+    private final int rightLimit;
+    private final int targetStringLength;
+    private final Random random;
+
+    public EmailService(JavaMailSender emailSender, EmailAuthenticationCodeRepository emailAuthenticationCodeRepository) {
+        this.emailSender = emailSender;
+        this.emailAuthenticationCodeRepository = emailAuthenticationCodeRepository;
+        this.leftLimit = 48;    // 0
+        this.rightLimit = 122;  // z
+        this.targetStringLength = 10;
+        this.random = new Random();
+    }
+
+
+    public void sendSignUpAuthenticationMail(SendAuthenticationEmailDto dto){
+        String authenticationCode = makeEmailAuthenticationCode();
+
+        emailAuthenticationCodeRepository.save(EmailAuthenticationCode.builder()
+                        .email(dto.getEmail())
+                        .code(authenticationCode)
+                        .build()
+        );
+
+        final MimeMessagePreparator preparator = message -> {
+            final MimeMessageHelper helper = new MimeMessageHelper(message);
+            helper.setTo(dto.getEmail());
+            helper.setSubject("PocketMark 회원가입 이메일 인증코드");
+            helper.setText(authenticationCode);
+        };
+
+        emailSender.send(preparator);
+
+    }
+
+    public String makeEmailAuthenticationCode(){
+
+        return random.ints(leftLimit,rightLimit + 1)
+                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+
+    }
+
+}

--- a/pocketmark_backend/src/main/resources/application.yml
+++ b/pocketmark_backend/src/main/resources/application.yml
@@ -11,6 +11,18 @@ spring:
         format_sql: true
   datasource:
     url: jdbc:h2:mem:testdb
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          socketFactory.class: javax.net.ssl.SSLSocketFactory
+          auth: true
+          starttls:
+            enable: true
   
 
 logging:


### PR DESCRIPTION
* 회원가입시 이메일 인증 코드 발송 및 인증코드 확인 구현
* 현재 이메일 발송 후 코드 인증 제한시간 3분으로 설정
* 인증코드의 경우 10글자로 설정하였는데 너무 길거나 짧은 거 같으면 수정 가능
*  이메일 발송의 경우 async로 구현하여 api  request를 하면 response는 바로 응답하지만 이메일의 경우 gmail mail server 환경에 따라 최대 1분이내로 발송
