### PR TITLE
HotFix. 태그 삭제 올바르지 않게 되는 문제 수정 + 성능개선

### DIFF
--- a/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/DataApiController.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/DataApiController.java
@@ -11,6 +11,7 @@ import com.example.pocketmark.service.DataService;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,7 +55,7 @@ public class DataApiController {
         @RequestBody DataCreateReq req
     ){
         dataService.createData(req.toServiceReq(), getUserId());
-        return ApiDataResponse.empty();
+        return ApiDataResponse.of(HttpStatus.OK.value(), "데이터가 성공적으로 생성되었습니다.", null);
     }
 
     //R

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/TagApiController.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/controller/api/TagApiController.java
@@ -20,6 +20,7 @@ import com.example.pocketmark.service.TagService;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,7 +66,7 @@ public class TagApiController {
         @RequestBody TagCreateBulkReq req
     ){
         tagService.createTags(req, getUserId());
-        return ApiDataResponse.empty();
+        return ApiDataResponse.of(HttpStatus.OK.value(), "태그가 성공적으로 생성되었습니다.", null);
     }
 
     //Delete
@@ -74,7 +75,7 @@ public class TagApiController {
         @RequestBody TagDeleteBulkReq req
     ){
         tagService.deleteTagsInBatch(req, getUserId());
-        return ApiDataResponse.empty();
+        return ApiDataResponse.of(HttpStatus.OK.value(), "태그가 성공적으로 삭제되었습니다.", null);
     }   
 
 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Item.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Item.java
@@ -37,6 +37,7 @@ import org.hibernate.annotations.PolymorphismType;
 import org.hibernate.annotations.Where;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Immutable;
+import org.springframework.data.domain.Persistable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -59,13 +60,32 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Where(clause = "deleted = false")
 @Table(indexes = @Index(name="i_item_parent_id", columnList = "parent_id"))
-public class Item extends BaseEntity{
+public class Item extends BaseEntity 
+    // implements Persistable<String>
+     {
     
     /* Table-Field Area */
     @Id
     // 조인속도향상 및 JPQL, DSL IN절 사용가능
     @Column(name="pk")
     private String pk;
+
+    // @Transient
+    // private boolean isNew=true;
+    // @Override
+    // public String getId() {
+    //     return this.pk;
+    // }
+
+    // @Override
+    // public boolean isNew(){
+    //     return this.isNew;
+    // }
+
+    // public void setIsNew(boolean isNew){
+    //     this.isNew = isNew;
+    // }
+    
     
     @Column(name="item_id") 
     private Long itemId; 
@@ -148,5 +168,8 @@ public class Item extends BaseEntity{
         private Long itemId;
         private Long userId;
     }
+
+
+    
 
 }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Item.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Item.java
@@ -60,9 +60,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Where(clause = "deleted = false")
 @Table(indexes = @Index(name="i_item_parent_id", columnList = "parent_id"))
-public class Item extends BaseEntity 
-    // implements Persistable<String>
-     {
+public class Item extends BaseEntity implements Persistable<String>{
     
     /* Table-Field Area */
     @Id
@@ -70,21 +68,21 @@ public class Item extends BaseEntity
     @Column(name="pk")
     private String pk;
 
-    // @Transient
-    // private boolean isNew=true;
-    // @Override
-    // public String getId() {
-    //     return this.pk;
-    // }
+    @Transient
+    private boolean isNew=true;
+    @Override
+    public String getId() {
+        return this.pk;
+    }
 
-    // @Override
-    // public boolean isNew(){
-    //     return this.isNew;
-    // }
+    @Override
+    public boolean isNew(){
+        return this.isNew;
+    }
 
-    // public void setIsNew(boolean isNew){
-    //     this.isNew = isNew;
-    // }
+    public void setIsNew(boolean isNew){
+        this.isNew = isNew;
+    }
     
     
     @Column(name="item_id") 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Tag.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Tag.java
@@ -37,31 +37,29 @@ import lombok.ToString;
 @Getter @ToString
 @Where(clause = "deleted = false")
 @Table(indexes = @Index(name="i_tag_name", columnList = "name"))
-public class Tag extends BaseImmutableEntity 
-    // implements Persistable<String>  
-    {
+public class Tag extends BaseImmutableEntity implements Persistable<String>{
     
     @Id
     // @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name ="id")
     private String id;
 
-    // @Transient
-    // private boolean isNew=true;
+    @Transient
+    private boolean isNew=true;
 
-    // @Override
-    // public String getId() {
-    //     return this.id;
-    // }
+    @Override
+    public String getId() {
+        return this.id;
+    }
 
-    // @Override
-    // public boolean isNew(){
-    //     return this.isNew;
-    // }
+    @Override
+    public boolean isNew(){
+        return this.isNew;
+    }
 
-    // public void setIsNew(boolean isNew){
-    //     this.isNew = isNew;
-    // }
+    public void setIsNew(boolean isNew){
+        this.isNew = isNew;
+    }
 
 
 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Tag.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/domain/main/Tag.java
@@ -13,11 +13,16 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinColumns;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
+import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import com.example.pocketmark.domain.base.BaseImmutableEntity;
 
+import org.hibernate.annotations.SQLInsert;
 import org.hibernate.annotations.Where;
+import org.springframework.data.domain.Persistable;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -32,11 +37,33 @@ import lombok.ToString;
 @Getter @ToString
 @Where(clause = "deleted = false")
 @Table(indexes = @Index(name="i_tag_name", columnList = "name"))
-public class Tag extends BaseImmutableEntity {
+public class Tag extends BaseImmutableEntity 
+    // implements Persistable<String>  
+    {
+    
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @ToString.Exclude
-    private Long id;
+    // @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="id")
+    private String id;
+
+    // @Transient
+    // private boolean isNew=true;
+
+    // @Override
+    // public String getId() {
+    //     return this.id;
+    // }
+
+    // @Override
+    // public boolean isNew(){
+    //     return this.isNew;
+    // }
+
+    // public void setIsNew(boolean isNew){
+    //     this.isNew = isNew;
+    // }
+
+
 
     //데이터분석 때 itemId, userId 랑 태그를 같이 xml로 만들어야할텐데
     //한 아이템을 두고 다른별칭을 어떻게 지었는가를 볼 수 있는 지표 (자연어 동의어 학습데이터)
@@ -80,13 +107,26 @@ public class Tag extends BaseImmutableEntity {
     //     this.item = item;
     // }
 
-    @Builder
+    
     public Tag(Long itemId, Long userId, String name, Item item){
+        this.id=makePK(itemId, userId, name);
         this.itemId=itemId;
         this.userId=userId;
         this.name=name;
         this.item=item;
     }
+
+    public static String makePK(Long itemId, Long userId, String name){
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.valueOf(itemId));
+        sb.append(", ");
+        sb.append(String.valueOf(userId));
+        sb.append(", ");
+        sb.append(name);
+        return sb.toString();
+    }
+
+
 
     /* 생성과 삭제는 Tag 컨트롤러로 */
     /* 업데이트는 프론트 UI에 없음 */

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/dto/common/ApiDataResponse.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/dto/common/ApiDataResponse.java
@@ -20,9 +20,16 @@ public class ApiDataResponse<T> extends ApiErrorResponse {
         super(true, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage());
         this.data = data;
     }
+    private ApiDataResponse(Integer errorCode, String customMessage, T data) {
+        super(true, errorCode, customMessage);
+        this.data = data;
+    }
 
     public static <T> ApiDataResponse<T> of(T data) {
         return new ApiDataResponse<>(data);
+    }
+    public static <T> ApiDataResponse<T> of(Integer errorCode, String customMessage, T data) {
+        return new ApiDataResponse<>(errorCode,customMessage,data);
     }
 
     public static <T> ApiDataResponse<T> empty() {

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/dto/main/DataDto.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/dto/main/DataDto.java
@@ -24,7 +24,7 @@ public class DataDto {
     @AllArgsConstructor @NoArgsConstructor // for objectMapper
     @Builder @Getter
     public static class DataRes{
-        Long parentId;
+        Long targetId;
         List<FolderResWithTag> folders;
         List<BookmarkResWithTag> bookmarks;
     }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/dto/main/TagDto.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/dto/main/TagDto.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.example.pocketmark.domain.main.Item;
 import com.example.pocketmark.domain.main.Tag;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,9 @@ public class TagDto {
     
     public interface TagRes{
         String getName();
+    }
+    public interface TagIdOnly{
+        String getId();
     }
 
     public interface TagResWithItemId{
@@ -56,12 +60,13 @@ public class TagDto {
                     .build();
         }
         public Tag toEntity(Long itemId, Long userId, Item item){
-            return Tag.builder()
-                    .itemId(itemId)
-                    .userId(userId)
-                    .name(this.name)
-                    .item(item)
-                    .build();
+            // return Tag.builder()
+            //         .itemId(itemId)
+            //         .userId(userId)
+            //         .name(this.name)
+            //         .item(item)
+            //         .build();
+            return new Tag(this.itemId, userId, this.name, item);
         }
 
         @Getter @Builder @ToString
@@ -70,12 +75,12 @@ public class TagDto {
             private Long itemId;
             private String name;
 
-            public Tag toEntity(Item item){
-                return Tag.builder()
-                        .name(this.name)
-                        .item(item)
-                        .build();
-            }
+            // public Tag toEntity(Item item){
+            //     // return Tag.builder()
+            //     //         .name(this.name)
+            //     //         .item(item)
+            //     //         .build();
+            // }
         }
     }
 

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/repository/TagRepository.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/repository/TagRepository.java
@@ -1,15 +1,17 @@
 package com.example.pocketmark.repository;
 
+import java.util.Collection;
 import java.util.List;
 
 import com.example.pocketmark.domain.main.Tag;
 import com.example.pocketmark.domain.main.Item.ItemPK;
+import com.example.pocketmark.dto.main.TagDto.TagIdOnly;
 import com.example.pocketmark.dto.main.TagDto.TagRes;
 import com.example.pocketmark.dto.main.TagDto.TagResWithItemId;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TagRepository extends JpaRepository<Tag, Long>{
+public interface TagRepository extends JpaRepository<Tag, String>{
     //공유게시판 태그검색
     List<TagResWithItemId> findByName(String name);
 
@@ -25,4 +27,8 @@ public interface TagRepository extends JpaRepository<Tag, Long>{
 
     //Read-ALL
     List<TagRes> findByUserId(Long userId);
+
+    //중복 태그 발견
+    List<TagIdOnly> findByIdIn(Collection<String> idList);
+
 }

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/security/provider/JwtUtil.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/security/provider/JwtUtil.java
@@ -23,8 +23,8 @@ public class JwtUtil {
 
     // deploy - 15분
     // developOnly - 6 hours
-    public static long ACCESS_TOKEN_EXPIRATION_TIME = 900000L;
-    // public static long ACCESS_TOKEN_EXPIRATION_TIME = Duration.ofMinutes(60*6).toMillis();
+    // public static long ACCESS_TOKEN_EXPIRATION_TIME = 900000L;
+    public static long ACCESS_TOKEN_EXPIRATION_TIME = Duration.ofMinutes(60*6).toMillis();
 
     // 24주
     public static long REFRESH_TOKEN_EXPIRATION_TIME = 604800000L;

--- a/pocketmark_backend/src/main/java/com/example/pocketmark/service/DataService.java
+++ b/pocketmark_backend/src/main/java/com/example/pocketmark/service/DataService.java
@@ -51,7 +51,7 @@ public class DataService {
 
         List<FolderResWithTag> folders = folderService.getAllFolders(userId);
         List<BookmarkResWithTag> bookmarks = bookmarkService.getAllBookmarks(userId);
-        DataRes data = DataRes.builder().parentId(0L).folders(folders).bookmarks(bookmarks).build();
+        DataRes data = DataRes.builder().targetId(0L).folders(folders).bookmarks(bookmarks).build();
 
         return data;
     }
@@ -62,7 +62,7 @@ public class DataService {
         if(parentId != null && userId != null){
             List<FolderResWithTag> folders = folderService.getFoldersByParentId(userId, parentId, pageable).getContent();
             List<BookmarkResWithTag> bookmarks = bookmarkService.getBoomarkByParentId(userId, parentId, pageable).getContent();
-            DataRes data = DataRes.builder().parentId(parentId).folders(folders).bookmarks(bookmarks).build();
+            DataRes data = DataRes.builder().targetId(parentId).folders(folders).bookmarks(bookmarks).build();
             return data;
         }else{
             return null;

--- a/pocketmark_backend/src/main/resources/application.yml
+++ b/pocketmark_backend/src/main/resources/application.yml
@@ -16,10 +16,13 @@ spring:
 logging:
   level:
     org:
+      # springframework.orm.jpa: DEBUG
+      # springframework.transaction: DEBUG
+      # springframework.transaction.interceptor: trace
       hibernate:
         type:
           descriptor:
-            sql: trace
+            sql: trace 
 
 server:
   port: 9090


### PR DESCRIPTION
* 태그삭제 올바르지 않게 되던 문제 수정

# [추가변경사항]
1. Tag 엔티티 PK를 업무키로 변경
> [기존] 동일 유저가 동일 아이템에 동일 태그를 생성할 시, Tag 테이블에 PK만 다르고 모두 내용이 같은 데이터가 생성되었음.

> [변경 후] PK를 동일유저+동일아이템+동일태그로 이루어진 대리키로 변경, 중복데이터 생성 방지 및 PK로 삭제로직 처리 update 1번으로 가능해짐

> [Trade-Off?] Insert 전에 중복데이터인지 확인하는 로직 추가 (N개의 요청에 대해 select 단 1번만 추가)

2. N개의 아이템(폴더, 북마크, 태그)를 Insert 시 영속성으로 인한 select 쿼리가 N개 발생하던 문제 해결
> 헤헷
